### PR TITLE
Fix(API): replace inactive OpenExchangeRates key with active one

### DIFF
--- a/JavaScript/1-intro.js
+++ b/JavaScript/1-intro.js
@@ -45,7 +45,7 @@ const purchase = {
 const API_EXCHANGE = {
   host: 'openexchangerates.org',
   path: '/api/latest.json?app_id=',
-  key: '1f43ea96b1e343fe94333dd2b97a109d',
+  key: '49db34e63fb048728a8380c5cf882f9f',
 };
 
 const getRate = async (currency) => {

--- a/JavaScript/Decompose1/config.js
+++ b/JavaScript/Decompose1/config.js
@@ -3,5 +3,5 @@
 module.exports = {
   host: 'openexchangerates.org',
   path: '/api/latest.json?app_id=',
-  key: '1f43ea96b1e343fe94333dd2b97a109d',
+  key: '49db34e63fb048728a8380c5cf882f9f',
 };

--- a/JavaScript/Decompose2/config.js
+++ b/JavaScript/Decompose2/config.js
@@ -3,5 +3,5 @@
 module.exports = {
   host: 'openexchangerates.org',
   path: '/api/latest.json?app_id=',
-  key: '1f43ea96b1e343fe94333dd2b97a109d',
+  key: '49db34e63fb048728a8380c5cf882f9f',
 };


### PR DESCRIPTION
## Summary
The previous OpenExchangeRates App ID had been deactivated, which caused
the API to return a `401 Unauthorized (app_id_inactive)` error.  
This broke the currency exchange functionality since rates could not be retrieved.

## Changes
- Replaced the inactive App ID with a new valid one from my OpenExchangeRates account.  
- Verified that the API now responds correctly and rates (e.g. USD → UAH) are available.  

## Reference
New App IDs can be managed here: https://openexchangerates.org/account/app-ids

## Notes
- This change restores the API functionality but **each developer should ideally
use their own App ID** from OpenExchangeRates, since free plan keys may be limited.
